### PR TITLE
Cast numeric arguments to number

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -91,7 +91,16 @@ export default class Parser {
         const currentArgDef = this.$command.$arguments[i]
         const currentArgInput = this.$args[i]
 
-        context.setArgument(currentArgDef.name, currentArgInput)
+        /**
+         * If the argument is a number, then we must cast the
+         * input to a number.
+         */
+        context.setArgument(
+          currentArgDef.name,
+          currentArgDef.type === Number
+            ? Number(currentArgInput)
+            : currentArgInput
+        )
       }
     }
 

--- a/src/decorators/Argument.ts
+++ b/src/decorators/Argument.ts
@@ -12,27 +12,31 @@ export default function Argument(
   return (target: any, property: string) => {
     const Command = target.constructor as CommandConstructorContract
 
+    /**
+     * Clear eventual previous commands data and ensure
+     * everything is readyy
+     */
     Command.boot()
 
-    if (typeof nameOrOptions === 'string') {
-      Command.addAssoc(property, nameOrOptions).addArgument({
-        name: nameOrOptions,
-        isRequired: true,
-      })
+    const name =
+      typeof nameOrOptions === 'string'
+        ? nameOrOptions
+        : nameOrOptions.name || property
+    const description =
+      typeof nameOrOptions === 'string' ? undefined : nameOrOptions.description
+    const type = Reflect.getMetadata('design:type', target, property)
 
-      return target
-    }
+    /**
+     * Registers the argument and its metadata as part of
+     * the targeted command.
+     */
+    Command.addAssoc(property, name).addArgument({
+      name,
+      description,
+      isRequired: true,
+      type,
+    })
 
-    if (typeof nameOrOptions === 'object') {
-      const name = nameOrOptions.name || property
-
-      Command.addAssoc(property, name).addArgument({
-        name,
-        description: nameOrOptions.description,
-        isRequired: Boolean(nameOrOptions.isRequired),
-      })
-
-      return target
-    }
+    return target
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata'
+
 /**
  * Application pillars
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface ArgumentDescriptor {
   name: string
   description?: string
   isRequired: boolean
+  type: any
 }
 
 export interface ArgumentDecoratorOptions {


### PR DESCRIPTION
So far, the value injected to the property assigned as an argument was always a string, even when it was number.

```ts
@Command('calc-age')
class CalcAgeCommand extends BaseCommand {
  @Argument()
  public year: number
}
```

Now Discapp automatically cast it to a number.
```