### PR TITLE
Feat: array arguments

### DIFF
--- a/src/CommandContext.ts
+++ b/src/CommandContext.ts
@@ -11,6 +11,15 @@ export default class CommandContext {
    */
   private readonly $context = new Map<string, any>()
 
+  constructor(private readonly $content: string = '') {}
+
+  /**
+   * The untreated content of the message
+   */
+  get content() {
+    return this.$content
+  }
+
   /**
    * Sets the author of the message
    *

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -7,7 +7,7 @@ export default class Storage {
   private static readonly $commands: CommandConstructorContract[] = []
 
   /**
-   * Returns all the command
+   * Returns all the commands
    */
   public static getAllCommands() {
     return [...this.$commands]
@@ -18,7 +18,7 @@ export default class Storage {
    *
    * @param command The command
    */
-  public static addCommand(command: CommandConstructorContract) {
-    this.$commands.push(command)
+  public static addCommand(Command: CommandConstructorContract) {
+    this.$commands.push(Command)
   }
 }

--- a/src/decorators/Command.ts
+++ b/src/decorators/Command.ts
@@ -1,4 +1,5 @@
 import Storage from '../Storage'
+import { isObject } from '../utils/isType'
 import { CommandDecoratorOptions } from '../types'
 
 export default function Command(name: string): ClassDecorator
@@ -10,15 +11,13 @@ export default function Command(
   nameOrOptions: string | CommandDecoratorOptions
 ) {
   return (Command: any) => {
+    const name = isObject(nameOrOptions) ? nameOrOptions.name : nameOrOptions
+    const description = isObject(nameOrOptions)
+      ? nameOrOptions.description
+      : undefined
+
     Command.boot()
-
-    const name =
-      typeof nameOrOptions === 'object' ? nameOrOptions.name : nameOrOptions
-    const description =
-      typeof nameOrOptions === 'object' ? nameOrOptions.description : undefined
-
     Command.setName(name).setDescription(description)
-
     Storage.addCommand(Command)
 
     return Command

--- a/src/exceptions/BadInputException.ts
+++ b/src/exceptions/BadInputException.ts
@@ -1,0 +1,3 @@
+import Exception from './Exception'
+
+export default class BadInputException extends Exception {}

--- a/src/exceptions/Exception.ts
+++ b/src/exceptions/Exception.ts
@@ -1,0 +1,11 @@
+export default class Exception extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly commandName: string,
+    public readonly argumentName: string,
+    public readonly message: string
+  ) {
+    super(message)
+    Error.captureStackTrace(this, this.constructor)
+  }
+}

--- a/src/exceptions/InvalidArgumentException.ts
+++ b/src/exceptions/InvalidArgumentException.ts
@@ -1,0 +1,3 @@
+import Exception from './Exception'
+
+export default class InvalidArgumentException extends Exception {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,4 +61,5 @@ export interface CommandConstructorContract {
   setDescription(description: string): this
   addAssoc(propertyKey: string, argumentKey: string): this
   addArgument(arg: ArgumentDescriptor): this
+  validate(): boolean
 }

--- a/src/utils/isType.ts
+++ b/src/utils/isType.ts
@@ -1,0 +1,7 @@
+export function isObject(target: any): target is object {
+  return typeof target === 'object'
+}
+
+export function isString(target: any): target is string {
+  return typeof target === 'string'
+}


### PR DESCRIPTION
This PR introduces array arguments, e.g:

## Array arguments

```ts
import { Command, BaseCommand, Argument } from 'discapp'

@Command('random')
export default class RandomCommand extends BaseCommand {
  @Argument()
  public possibilities: string[]

  public execute() {
    const random = Math.floor(Math.random() * this.possibilities.length)
    return this.possibilities[random]
  }
}
```

From the user input:

```
random 14 15 16
```

The property `possibilities` will receive `['14', '15', '16']`.

## Command validation in the application boot

Previously, commands were not checked during Discapp boot, this could lead to runtime errors for malformatted commands. Example of malformatted command:

```ts
import { Command, BaseCommand, Argument } from 'discapp'

@Command('random')
export default class RandomCommand extends BaseCommand {
  @Argument()
  public possibilities: string[]

  @Argument()
  public possibility: string
}
```

Since array arguments should always be the last argument, but is defined before the possibility argument, Discapp will throw an error:

```
Error: Argument possibilities can't be a array.
```

By now if a single command is invalid the entire application will not start, will fix this in another PR.

## Input errors

Before this PR there was no difference between user errors or command definition errors, from this PR the `Parser` only validates the user input, command validation is made by the `BaseCommand.validate` static method.

This PR also starts the error report feature, will improve this in the future.

![image](https://user-images.githubusercontent.com/21691434/106123161-58c06a00-6138-11eb-8baa-8710734efbb6.png)
