### PR TITLE
Add 'afterExecute' and 'beforeExecute' events

### DIFF
--- a/src/BaseCommand.ts
+++ b/src/BaseCommand.ts
@@ -165,7 +165,17 @@ export default abstract class BaseCommand {
   }
 
   /**
+   * Executes before the command
+   */
+  public beforeExecute() {}
+
+  /**
+   * Executes after the command
+   */
+  public afterExecute() {}
+
+  /**
    * Executes the command
    */
-  abstract execute(): any
+  public abstract execute(): any
 }

--- a/src/Invoker.ts
+++ b/src/Invoker.ts
@@ -44,8 +44,7 @@ export default class Invoker {
    * Set the associateds properties in the command instance
    */
   private setAssociatedProperties() {
-    const Command = (this.$command
-      .constructor as unknown) as CommandConstructorContract
+    const Command = this.$command.constructor as CommandConstructorContract
 
     for (const [propertyName, argumentName] of Command.$assocs.entries()) {
       if (this.$context.hasArgument(argumentName)) {
@@ -61,6 +60,10 @@ export default class Invoker {
    * Invokes the command
    */
   public async invoke() {
+    /**
+     * Call the global 'beforeCommand' hooks with, usefull
+     * for third party codes being able to hook Discapp
+     */
     await callEach(this.$hooks.beforeCommand, [
       {
         context: this.$context,
@@ -69,8 +72,27 @@ export default class Invoker {
     ])
 
     this.setAssociatedProperties()
+
+    /**
+     * Call the global 'afterCommand' hooks. Useful
+     * for plugins to being able to hook into a
+     * Discapp application.
+     */
+    await this.$command.beforeExecute()
+
     const response = await this.$command.execute()
 
+    /**
+     * Executes the 'afterExecute' function, if it exists
+     * after executing the command
+     */
+    await this.$command.afterExecute()
+
+    /**
+     * Call the global 'afterCommand' hooks. Useful
+     * for plugins to being able to hook into a
+     * Discapp application.
+     */
     await callEach(this.$hooks.afterCommand, [
       {
         context: this.$context,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,9 @@ export * from './types'
 export { default as Command } from './decorators/Command'
 export { default as Argument } from './decorators/Argument'
 export * from './decorators/associations'
+
+/**
+ * Exceptions
+ */
+export { default as BadInputException } from './exceptions/BadInputException'
+export { default as InvalidArgumentException } from './exceptions/InvalidArgumentException'


### PR DESCRIPTION
Add `beforeExecute` and `afterExecute` methods to `BaseCommand`. This methos are, by default, empty, but can be override in children classes (aka your commands), this will also allow some nice features I'm testing.

```ts
import { Command, BaseCommand } from 'discapp'

@Command('any')
class AnyCommand extends BaseCommand {
  public beforeExecute() {
    // Will be invoked before the execute method
  }

  public execute() {}

  public afterExecute() {
    // Will be invoked after the execute method
  }
}
```