### PR TITLE
Add 'allOf' and 'oneOf' helpers for roles and permissions

### DIFF
--- a/src/BaseCommand/StaticCommandContract.ts
+++ b/src/BaseCommand/StaticCommandContract.ts
@@ -1,5 +1,6 @@
 import CommandContract from './CommandContract'
 import { ArgumentDescriptor } from '../types'
+import { Collection } from '../Collections'
 import { PermissionString } from 'discord.js'
 
 export default interface StaticCommandContract {
@@ -7,8 +8,8 @@ export default interface StaticCommandContract {
   description: string
   $arguments: ArgumentDescriptor[]
   readonly $assocs: Map<string, string>
-  readonly $roles: Set<string>
-  readonly $permissions: Set<PermissionString>
+  readonly $roles: Collection
+  readonly $permissions: Collection
 
   new (): CommandContract
   boot(): this
@@ -16,8 +17,8 @@ export default interface StaticCommandContract {
   setDescription(description: string): this
   addAssoc(propertyKey: string, argumentKey: string): this
   addArgument(arg: ArgumentDescriptor): this
-  setPermissions(permissions: PermissionString[]): this
-  setRoles(roles: string[]): this
+  setPermissions(permissions: PermissionString[] | Collection): this
+  setRoles(roles: Collection | string[]): this
   getArgument(name: string): ArgumentDescriptor | undefined
   validate(): void
 }

--- a/src/BaseCommand/index.ts
+++ b/src/BaseCommand/index.ts
@@ -3,6 +3,7 @@ import { PermissionString } from 'discord.js'
 import InvalidArgumentException from '../Exceptions/InvalidArgumentException'
 import CommandContract from './CommandContract'
 import { ArgumentDescriptor } from '../types'
+import { allOf, Collection } from '../Collections'
 
 export default abstract class BaseCommand implements CommandContract {
   /**
@@ -28,12 +29,12 @@ export default abstract class BaseCommand implements CommandContract {
   /**
    * Command required permissionss
    */
-  public static $permissions = new Set<PermissionString>()
+  public static $permissions: Collection = allOf()
 
   /**
    * Command required roles
    */
-  public static $roles = new Set<string>()
+  public static $roles: Collection = allOf()
 
   /**
    * Whether the Command was booted
@@ -49,8 +50,8 @@ export default abstract class BaseCommand implements CommandContract {
       this.code = ''
       this.description = ''
       this.$assocs = new Map<string, string>()
-      this.$roles = new Set<string>()
-      this.$permissions = new Set<PermissionString>()
+      this.$roles = allOf()
+      this.$permissions = allOf()
     }
 
     this.$isBooted = true
@@ -87,9 +88,11 @@ export default abstract class BaseCommand implements CommandContract {
    *
    * @param permissions The permissions
    */
-  public static setPermissions(permissions: PermissionString[]) {
-    for (const permission of permissions) {
-      this.$permissions.add(permission)
+  public static setPermissions(permissions: PermissionString[] | Collection) {
+    if (Array.isArray(permissions)) {
+      this.$permissions = allOf(...permissions)
+    } else {
+      this.$permissions = permissions
     }
 
     return this
@@ -100,8 +103,10 @@ export default abstract class BaseCommand implements CommandContract {
    * @param roles The roles
    */
   public static setRoles(roles: string[]) {
-    for (const role of roles) {
-      this.$roles.add(role)
+    if (Array.isArray(roles)) {
+      this.$roles = allOf(...roles)
+    } else {
+      this.$roles = roles
     }
 
     return this

--- a/src/Collections/index.ts
+++ b/src/Collections/index.ts
@@ -1,0 +1,52 @@
+export enum CollectionType {
+  ONE_OF,
+  ALL_OF,
+}
+
+export abstract class Collection {
+  protected $collection = new Set<string>()
+
+  abstract get type(): CollectionType
+
+  public add(rp: string) {
+    this.$collection.add(rp)
+
+    return this
+  }
+
+  public has(rp: string) {
+    return this.$collection.has(rp)
+  }
+
+  [Symbol.iterator]() {
+    return this.$collection.values()
+  }
+}
+
+class OneOf extends Collection {
+  public type = CollectionType.ONE_OF
+}
+
+class AllOf extends Collection {
+  public type = CollectionType.ALL_OF
+}
+
+export function oneOf<T extends string = string>(...roleOrPermissions: T[]) {
+  const collection = new OneOf()
+
+  for (const roleOrPermission of roleOrPermissions) {
+    collection.add(roleOrPermission)
+  }
+
+  return collection
+}
+
+export function allOf<T extends string = string>(...roleOrPermissions: T[]) {
+  const collection = new AllOf()
+
+  for (const roleOrPermission of roleOrPermissions) {
+    collection.add(roleOrPermission)
+  }
+
+  return collection
+}

--- a/src/Invoker/index.ts
+++ b/src/Invoker/index.ts
@@ -1,11 +1,14 @@
+import { GuildMember, PermissionString } from 'discord.js'
+
 import CommandContract from '../BaseCommand/CommandContract'
 import StaticCommandContract from '../BaseCommand/StaticCommandContract'
 import CommandContext from '../CommandContext'
 import CommandContextContract from '../CommandContext/CommandContextContract'
 import InvokerContract from './InvokerContract'
 import callEach from '../utils/callEach'
-import { InvokerHooks } from '../types'
 import ForbiddenCommandException from '../Exceptions/ForbiddenCommandException'
+import { Collection, CollectionType } from '../Collections'
+import { InvokerHooks } from '../types'
 
 export default class Invoker implements InvokerContract {
   /**
@@ -58,38 +61,155 @@ export default class Invoker implements InvokerContract {
   }
 
   /**
-   * Check if the user has permission for executing this command
+   * Check if the user has the required permissions
+   *
+   * @param member The member
+   * @param $permissions The required permissions
    */
-  private checkPermissions() {
-    const member = this.$context.getMember()
+  private checkPermissions(member: GuildMember, $permissions: Collection) {
+    for (const $permission of $permissions) {
+      /**
+       * Check if the user has the permissionn
+       */
+      const hasRole = member.hasPermission($permission as PermissionString)
 
-    if (member) {
-      for (const $role of this.Command.$roles) {
-        const hasRole = member.roles.cache.find(role => role.name === $role)
-
+      /**
+       * If the collection is of the type 'AllOf', then if the user
+       * doesn't have one of the roles we should  throw
+       */
+      if ($permissions.type === CollectionType.ALL_OF) {
         if (!hasRole) {
+          const requiredPermissions = Array.from($permissions).join(', ')
+
           throw new ForbiddenCommandException(
-            'MISSING_ROLE',
+            'MISSING_PERMISSION',
             this.Command.code,
-            $role,
-            `This commands requires you to have the role: '${$role}', but you don't`
+            requiredPermissions,
+            `This command required you to have the roles: ${requiredPermissions}, but you don't`
           )
         }
       }
 
-      for (const $permission of this.Command.$permissions) {
-        if (!member.hasPermission($permission)) {
-          throw new ForbiddenCommandException(
-            'MISSING_PERMISSION',
-            this.Command.code,
-            $permission,
-            `This commands requires you to have the permission: '${$permission}', but you don't`
-          )
+      /**
+       * If the collection is of the type 'OneOf', then if user has
+       * one of the roles we should return true
+       */
+      if ($permissions.type === CollectionType.ONE_OF) {
+        if (hasRole) {
+          return true
         }
       }
     }
 
+    /**
+     * If the collection is of the type 'AllOf', then if nothing
+     * then the user has the permission
+     */
+    if ($permissions.type === CollectionType.ALL_OF) {
+      return true
+    }
+
+    /**
+     * If the collection is of the type 'OneOf', then if nothing
+     * was returned the user doesn't have permission, hence we
+     * should throw
+     */
+    if ($permissions.type === CollectionType.ONE_OF) {
+      const requiredPermissions = Array.from($permissions).join(', ')
+
+      throw new ForbiddenCommandException(
+        'MISSING_PERMISSION',
+        this.Command.code,
+        requiredPermissions,
+        `This command required you to have one of the permissions: ${requiredPermissions}, but you don't have any`
+      )
+    }
+
     return true
+  }
+
+  /**
+   * Check if the member has the required roles
+   *
+   * @param member The member
+   * @param $roles The required roles
+   */
+  private checkRoles(member: GuildMember, $roles: Collection) {
+    for (const $role of $roles) {
+      /**
+       * Check if the user has an role with an id or name that
+       * matches
+       */
+      const hasRole = member.roles.cache.find(
+        role => role.name === $role || role.id === $role
+      )
+
+      /**
+       * If the collection is of the type 'AllOf', then if the user
+       * doesn't have one of the roles we should  throw
+       */
+      if ($roles.type === CollectionType.ALL_OF) {
+        if (!hasRole) {
+          const requiredRoles = Array.from($roles).join(', ')
+
+          throw new ForbiddenCommandException(
+            'MISSING_ROLE',
+            this.Command.code,
+            requiredRoles,
+            `This command required you to have the roles: ${requiredRoles}, but you don't`
+          )
+        }
+      }
+
+      /**
+       * If the collection is of the type 'OneOf', then if user has
+       * one of the roles we should return true
+       */
+      if ($roles.type === CollectionType.ONE_OF) {
+        if (hasRole) {
+          return true
+        }
+      }
+    }
+
+    /**
+     * If the collection is of the type 'AllOf', then if nothing
+     * then the user has the permission
+     */
+    if ($roles.type === CollectionType.ALL_OF) {
+      return true
+    }
+
+    /**
+     * If the collection is of the type 'OneOf', then if nothing
+     * was returned the user doesn't have permission, hence we
+     * should throw
+     */
+    if ($roles.type === CollectionType.ONE_OF) {
+      const requiredRoles = Array.from($roles).join(', ')
+
+      throw new ForbiddenCommandException(
+        'MISSING_ROLE',
+        this.Command.code,
+        requiredRoles,
+        `This command required you to have one of the roles: ${requiredRoles}, but you don't have any`
+      )
+    }
+
+    return true
+  }
+
+  /**
+   * Check if the user has permission for executing this command
+   */
+  private canExecute() {
+    const member = this.$context.getMember()
+    const { $roles, $permissions } = this.Command
+
+    const hasRoles = this.checkRoles(member, $roles)
+    const hasPermissions = this.checkPermissions(member, $permissions)
+
+    return hasRoles && hasPermissions
   }
 
   /**
@@ -131,6 +251,11 @@ export default class Invoker implements InvokerContract {
    */
   public async invoke() {
     /**
+     * The response of the command
+     */
+    let response: any = undefined
+
+    /**
      * Call the global 'beforeCommand' hooks with, usefull
      * for third party codes being able to hook Discapp
      */
@@ -141,35 +266,46 @@ export default class Invoker implements InvokerContract {
       },
     ])
 
-    this.setAssociatedProperties()
-    this.checkPermissions()
+    try {
+      /**
+       * Ensures the user can execute this command, otherwise
+       * throws an error
+       */
+      this.canExecute()
 
-    /**
-     * Call the global 'afterCommand' hooks. Useful
-     * for plugins to being able to hook into a
-     * Discapp application.
-     */
-    await this.$command.beforeExecute()
+      /**
+       * Inject the properties into the command
+       */
+      this.setAssociatedProperties()
 
-    const response = await this.$command.execute()
+      /**
+       * Call the global 'afterCommand' hooks. Useful for plugins
+       * to being able to hook into a Discapp application.
+       */
+      await this.$command.beforeExecute()
 
-    /**
-     * Executes the 'afterExecute' function, if it exists
-     * after executing the command
-     */
-    await this.$command.afterExecute()
+      response = await this.$command.execute()
 
-    /**
-     * Call the global 'afterCommand' hooks. Useful
-     * for plugins to being able to hook into a
-     * Discapp application.
-     */
-    await callEach(this.$hooks.afterCommand, [
-      {
-        context: this.$context,
-        command: this.$command.constructor,
-      },
-    ])
+      /**
+       * Executes the 'afterExecute' function, if it exists after
+       * executing the command
+       */
+      await this.$command.afterExecute()
+    } catch (error) {
+      throw error
+    } finally {
+      /**
+       * Call the global 'afterCommand' hooks. Useful
+       * for plugins to being able to hook into a
+       * Discapp application.
+       */
+      await callEach(this.$hooks.afterCommand, [
+        {
+          context: this.$context,
+          command: this.$command.constructor,
+        },
+      ])
+    }
 
     return response
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,11 @@ export { default as Parser } from './Parser'
 export { default as Invoker } from './Invoker'
 
 /**
+ * Utilitary
+ */
+export * from './Collections'
+
+/**
  * Types and interfaces
  */
 export { default as ApplicationContract } from './Application/ApplicationContract'

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,14 +6,15 @@ import {
   TextChannel,
   User,
 } from 'discord.js'
+import { Collection } from './Collections'
 import CommandContract from './BaseCommand/CommandContract'
 import CommandContextContract from './CommandContext/CommandContextContract'
 
 export interface CommandDecoratorOptions {
   code: string
   description?: string
-  roles?: string[]
-  permissions?: PermissionString[]
+  roles?: string[] | Collection
+  permissions?: PermissionString[] | Collection
 }
 
 export interface ArgumentDescriptor {

--- a/test/roles-and-permissions.spec.ts
+++ b/test/roles-and-permissions.spec.ts
@@ -1,5 +1,12 @@
 import { GuildMember, PermissionString } from 'discord.js'
-import { BaseCommand, Command, CommandContext, Invoker } from '../src'
+import {
+  BaseCommand,
+  Command,
+  CommandContext,
+  Invoker,
+  allOf,
+  oneOf,
+} from '../src'
 
 @Command({
   code: 'permission',
@@ -14,6 +21,14 @@ class PermissionCommand extends BaseCommand {
   permissions: ['SEND_MESSAGES', 'ADD_REACTIONS'],
 })
 class MultiplePermissionCommand extends BaseCommand {
+  public execute() {}
+}
+
+@Command({
+  code: 'all_of_permission',
+  permissions: allOf('SEND_MESSAGES', 'ADD_REACTIONS'),
+})
+class AllOfPermissionCommannd extends BaseCommand {
   public execute() {}
 }
 
@@ -33,102 +48,223 @@ class MultipleRoleCommand extends BaseCommand {
   public execute() {}
 }
 
+@Command({
+  code: 'all_of_role',
+  roles: allOf('admin', 'mantainer'),
+})
+class AllOfRoleCommand extends BaseCommand {
+  public execute() {}
+}
+
+@Command({
+  code: 'one_of_role',
+  roles: oneOf('admin', 'mantainer'),
+})
+class OneOfRoleCommand extends BaseCommand {
+  public execute() {}
+}
+
 describe('Roles and permisssions', () => {
-  it('should allow if user have the permission', () => {
-    const context = new CommandContext()
+  describe('Roles', () => {
+    it('should allow if user have the role', () => {
+      const context = new CommandContext()
 
-    context.setMember(({
-      hasPermission: () => true,
-    } as unknown) as GuildMember)
+      context.setMember(({
+        roles: {
+          cache: [
+            {
+              name: 'admin',
+            },
+          ],
+        },
+      } as unknown) as GuildMember)
 
-    return expect(
-      new Invoker(PermissionCommand).withContext(context).invoke()
-    ).resolves.not.toThrow()
+      return expect(
+        new Invoker(RoleCommand).withContext(context).invoke()
+      ).resolves.not.toThrow()
+    })
+
+    it("should throw if user doesn't have the role", () => {
+      const context = new CommandContext()
+
+      context.setMember(({
+        roles: {
+          cache: [],
+        },
+      } as unknown) as GuildMember)
+
+      return expect(
+        new Invoker(RoleCommand).withContext(context).invoke()
+      ).rejects.toThrow()
+    })
+
+    it("should throw if user doesn't have the role", () => {
+      const context = new CommandContext()
+
+      context.setMember(({
+        roles: {
+          cache: [],
+        },
+      } as unknown) as GuildMember)
+
+      return expect(
+        new Invoker(RoleCommand).withContext(context).invoke()
+      ).rejects.toThrow()
+    })
+
+    it("should throw if user doesn't have one of the roles", () => {
+      const context = new CommandContext()
+
+      context.setMember(({
+        roles: {
+          cache: [
+            {
+              name: 'adminn',
+            },
+          ],
+        },
+      } as unknown) as GuildMember)
+
+      return expect(
+        new Invoker(MultipleRoleCommand).withContext(context).invoke()
+      ).rejects.toThrow()
+    })
+
+    it("should throw if user doesn't have one of roles assigned as allOf", () => {
+      const context = new CommandContext()
+
+      context.setMember(({
+        roles: {
+          cache: [
+            {
+              name: 'admin',
+            },
+          ],
+        },
+      } as unknown) as GuildMember)
+
+      return expect(
+        new Invoker(AllOfRoleCommand).withContext(context).invoke()
+      ).rejects.toThrow()
+    })
+
+    it('should allow if user have all of roles assigned as allOf', () => {
+      const context = new CommandContext()
+
+      context.setMember(({
+        roles: {
+          cache: [
+            {
+              name: 'admin',
+            },
+            {
+              name: 'mantainer',
+            },
+          ],
+        },
+      } as unknown) as GuildMember)
+
+      return expect(
+        new Invoker(AllOfRoleCommand).withContext(context).invoke()
+      ).resolves.not.toThrow()
+    })
+
+    it('should allow if user has at leat one of the roles assigned as oneOf', () => {
+      const context = new CommandContext()
+
+      context.setMember(({
+        roles: {
+          cache: [
+            {
+              name: 'admin',
+            },
+          ],
+        },
+      } as unknown) as GuildMember)
+
+      return expect(
+        new Invoker(OneOfRoleCommand).withContext(context).invoke()
+      ).resolves.not.toThrow()
+    })
+
+    it("should throw if user doesn't has at leat any of the roles assigned as oneOf", () => {
+      const context = new CommandContext()
+
+      context.setMember(({
+        roles: {
+          cache: [],
+        },
+      } as unknown) as GuildMember)
+
+      return expect(
+        new Invoker(OneOfRoleCommand).withContext(context).invoke()
+      ).rejects.toThrow()
+    })
   })
 
-  it("should throw if user does'nt have the permission", () => {
-    const context = new CommandContext()
+  describe('Permission', () => {
+    it('should allow if user have the permission', () => {
+      const context = new CommandContext()
 
-    context.setMember(({
-      hasPermission: () => false,
-    } as unknown) as GuildMember)
+      context.setMember(({
+        hasPermission: () => true,
+      } as unknown) as GuildMember)
 
-    return expect(
-      new Invoker(PermissionCommand).withContext(context).invoke()
-    ).rejects.toThrow()
-  })
+      return expect(
+        new Invoker(PermissionCommand).withContext(context).invoke()
+      ).resolves.not.toThrow()
+    })
 
-  it("should throw if user does'nt have one of the permissions", () => {
-    const context = new CommandContext()
+    it("should throw if user does'nt have the permission", () => {
+      const context = new CommandContext()
 
-    context.setMember(({
-      hasPermission: (permission: PermissionString) => {
-        return permission === 'ADD_REACTIONS' ? false : true
-      },
-    } as unknown) as GuildMember)
+      context.setMember(({
+        hasPermission: () => false,
+      } as unknown) as GuildMember)
 
-    return expect(
-      new Invoker(MultiplePermissionCommand).withContext(context).invoke()
-    ).rejects.toThrow()
-  })
+      return expect(
+        new Invoker(PermissionCommand).withContext(context).invoke()
+      ).rejects.toThrow()
+    })
 
-  it('should allow if user have the role', () => {
-    const context = new CommandContext()
+    it("should throw if user does'nt have one of the permissions", () => {
+      const context = new CommandContext()
 
-    context.setMember(({
-      roles: {
-        cache: [
-          {
-            name: 'admin',
-          },
-        ],
-      },
-    } as unknown) as GuildMember)
+      context.setMember(({
+        hasPermission: (permission: PermissionString) => {
+          return permission === 'ADD_REACTIONS' ? false : true
+        },
+      } as unknown) as GuildMember)
 
-    return expect(
-      new Invoker(RoleCommand).withContext(context).invoke()
-    ).resolves.not.toThrow()
-  })
+      return expect(
+        new Invoker(MultiplePermissionCommand).withContext(context).invoke()
+      ).rejects.toThrow()
+    })
 
-  it("should throw if user doesn't have the role", () => {
-    const context = new CommandContext()
+    it("should throw if user does'nt have one of the permissions assigned as allOf", () => {
+      const context = new CommandContext()
 
-    context.setMember(({
-      roles: {
-        cache: [],
-      },
-    } as unknown) as GuildMember)
+      context.setMember(({
+        hasPermission: (permission: PermissionString) => {
+          return permission === 'ADD_REACTIONS' ? false : true
+        },
+      } as unknown) as GuildMember)
 
-    return expect(
-      new Invoker(RoleCommand).withContext(context).invoke()
-    ).rejects.toThrow()
-  })
+      return expect(
+        new Invoker(AllOfPermissionCommannd).withContext(context).invoke()
+      ).rejects.toThrow()
+    })
 
-  it("should throw if user doesn't have the role", () => {
-    const context = new CommandContext()
+    it('should allow if user has all tthe permissions assigned as allOf', () => {
+      const context = new CommandContext()
 
-    context.setMember(({
-      roles: {
-        cache: [],
-      },
-    } as unknown) as GuildMember)
+      context.setMember(({
+        hasPermission: () => true,
+      } as unknown) as GuildMember)
 
-    return expect(
-      new Invoker(RoleCommand).withContext(context).invoke()
-    ).rejects.toThrow()
-  })
-
-  it("should throw if user doesn't have one of the roles", () => {
-    const context = new CommandContext()
-
-    context.setMember(({
-      roles: {
-        cache: ['admin'],
-      },
-    } as unknown) as GuildMember)
-
-    return expect(
-      new Invoker(MultipleRoleCommand).withContext(context).invoke()
-    ).rejects.toThrow()
+      return expect(
+        new Invoker(AllOfPermissionCommannd).withContext(context).invoke()
+      ).resolves.not.toThrow()
+    })
   })
 })


### PR DESCRIPTION
Implements the functions `allOf` and `oneOf` as in #14 

```ts
@Command({
  code: 'my_command',
  roles:  oneOf('admin', 'moderator'),
  permissions: allOf('SEND_MESSAGES', 'ADD_REACTIONS')
})
```