### PR TITLE
Feat: reply and message

### DIFF
--- a/src/Application/index.ts
+++ b/src/Application/index.ts
@@ -61,19 +61,19 @@ export default class Application implements ApplicationContract {
   /**
    * Respond the user input
    *
-   * @param channel The channel
+   * @param message The channel
    * @param response The response
    */
-  private respond(channel: MessageContract['channel'], responses: any) {
+  private respond(message: MessageContract, responses: any) {
     if (Array.isArray(responses)) {
       for (const response of responses) {
-        this.respond(channel, response)
+        this.respond(message, response)
       }
     } else {
       if (typeof responses === 'string') {
-        channel.send(responses)
+        message.reply(responses)
       } else {
-        channel.send({ embed: responses })
+        message.reply({ embed: responses })
       }
     }
   }
@@ -137,7 +137,7 @@ export default class Application implements ApplicationContract {
    * @param message The message
    */
   private async onInput(message: MessageContract) {
-    const { content: originalContent, author, channel, member } = message
+    const { content: originalContent } = message
     let content = originalContent
 
     if (content.startsWith(this.$config.prefix)) {
@@ -154,11 +154,7 @@ export default class Application implements ApplicationContract {
         const parser = new Parser(content).forCommand(Command)
 
         if (parser.isValid()) {
-          const context = parser
-            .makeContext()
-            .setAuthor(author)
-            .setChannel(channel)
-            .setMember(member)
+          const context = parser.makeContext().setMessage(message)
 
           /**
            * Invokes the command with its context and
@@ -179,7 +175,7 @@ export default class Application implements ApplicationContract {
            * it to the channel
            */
           if (response) {
-            this.respond(channel, response)
+            this.respond(message, response)
           }
         }
       } catch (error) {
@@ -195,7 +191,7 @@ export default class Application implements ApplicationContract {
             .setColor('#ff6e6c')
             .setTimestamp()
 
-          this.respond(channel, errorMessage)
+          this.respond(message, errorMessage)
         } else if (error instanceof ForbiddenCommandException) {
           const errorMessage = new MessageEmbed()
             .setTitle('Error: forbidden')
@@ -208,7 +204,7 @@ export default class Application implements ApplicationContract {
             .setColor('#ff6e6c')
             .setTimestamp()
 
-          this.respond(channel, errorMessage)
+          this.respond(message, errorMessage)
         } else {
           throw error
         }

--- a/src/CommandContext/CommandContextContract.ts
+++ b/src/CommandContext/CommandContextContract.ts
@@ -12,5 +12,6 @@ export default interface CommandContextContract {
   getAuthor(): MessageContract['author'] | undefined
   getChannel(): MessageContract['channel'] | undefined
   getMember(): MessageContract['member'] | undefined
+  getMessage(): MessageContract | undefined
   clear(): this
 }

--- a/src/CommandContext/index.ts
+++ b/src/CommandContext/index.ts
@@ -5,7 +5,7 @@ export default class CommandContext implements CommandContextContract {
   /**
    * List of reserved words
    */
-  private readonly reservedWords = ['channel', 'author', 'member']
+  private readonly reservedWords = ['channel', 'author', 'member', 'message']
 
   /**
    * The context mapping
@@ -26,6 +26,21 @@ export default class CommandContext implements CommandContextContract {
    */
   get content() {
     return this.$content
+  }
+
+  /**
+   * Sets the message object
+   *
+   * @param member
+   */
+  public setMessage(message: MessageContract) {
+    this.$context.set('message', message)
+
+    this.setAuthor(message.author)
+      .setChannel(message.channel)
+      .setMember(message.member)
+
+    return this
   }
 
   /**
@@ -125,6 +140,13 @@ export default class CommandContext implements CommandContextContract {
    */
   public getChannel(): MessageContract['channel'] | undefined {
     return this.get('channel')
+  }
+
+  /**
+   * Returns the channel the message has been sent to
+   */
+  public getMessage(): MessageContract | undefined {
+    return this.get('message')
   }
 
   /**

--- a/src/Decorators/Argument.ts
+++ b/src/Decorators/Argument.ts
@@ -29,6 +29,7 @@ export default function Argument(
     }
 
     Command.boot()
-    Command.addAssoc(property, definition.name).addArgument(definition)
+      .addAssoc(property, definition.name)
+      .addArgument(definition)
   }
 }

--- a/src/Decorators/associations.ts
+++ b/src/Decorators/associations.ts
@@ -13,3 +13,4 @@ function createAssociation(argName: string) {
 export const Author = createAssociation('author')
 export const Channel = createAssociation('channel')
 export const Member = createAssociation('member')
+export const Message = createAssociation('message')

--- a/src/Decorators/associations.ts
+++ b/src/Decorators/associations.ts
@@ -4,8 +4,8 @@ function createAssociation(argName: string) {
   return function() {
     return (target: any, property: string) => {
       const Command = target.constructor as StaticCommandContract
-      Command.boot()
-      Command.addAssoc(property, argName || property)
+
+      Command.boot().addAssoc(property, argName || property)
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,4 @@
-import {
-  DMChannel,
-  GuildMember,
-  NewsChannel,
-  PermissionString,
-  TextChannel,
-  User,
-} from 'discord.js'
+import { Message, PermissionString } from 'discord.js'
 import { Collection } from './Collections'
 import CommandContract from './BaseCommand/CommandContract'
 import CommandContextContract from './CommandContext/CommandContextContract'
@@ -30,12 +23,7 @@ export interface ArgumentDecoratorOptions {
   isRequired?: boolean
 }
 
-export interface MessageContract {
-  readonly content: string
-  readonly author: User
-  readonly member: GuildMember
-  readonly channel: TextChannel | DMChannel | NewsChannel
-}
+export interface MessageContract extends Message {}
 
 export interface DiscappConfig {
   commandsDirectory: string
@@ -53,5 +41,5 @@ export interface DiscappHooks extends InvokerHooks {}
 
 export type CommandHookFunction = (command: {
   context: CommandContextContract
-  descriptor: CommandContract
+  command: CommandContract
 }) => void


### PR DESCRIPTION
## Reply

Now, by default messages returned by commands are send using `message.reply` instead of `message.channel.send`.

## Message

Add `@Message` decorator.