### PR TITLE
Feat: mention argument

### DIFF
--- a/src/Application/index.ts
+++ b/src/Application/index.ts
@@ -40,6 +40,7 @@ export default class Application implements ApplicationContract {
     private readonly $client = new Client()
   ) {
     this.setConfig(config)
+    Storage.setClient($client)
   }
 
   /**

--- a/src/Parser/index.ts
+++ b/src/Parser/index.ts
@@ -1,3 +1,4 @@
+import Storage from '../Storage'
 import CommandContext from '../CommandContext'
 import ParserContract from './ParserContract'
 import BadInputException from '../Exceptions/BadInputException'
@@ -99,7 +100,7 @@ export default class Parser implements ParserContract {
         if (type === Array) {
           context.set(name, this.$arguments.slice(i))
         } else {
-          const argValue = this.$arguments[i]
+          const argValue: string = this.$arguments[i]
 
           /**
            * If ther argument is optional and value is not given,
@@ -110,13 +111,32 @@ export default class Parser implements ParserContract {
             continue
           }
 
-          /**
-           * If the argument is a numeric argument, thne we have
-           * to cast it to number
+          /***
+           * If the Argument is of type User, then we should
+           * convert it to an Discord.js User instance
            */
-          const value = type === Number ? Number(argValue) : argValue
+          if (type.name === 'User') {
+            if (argValue.startsWith('<@') && argValue.endsWith('>')) {
+              let mention = argValue.slice(2, -1)
 
-          context.set(name, value)
+              if (mention.startsWith('!')) {
+                mention = mention.slice(1)
+              }
+
+              const user = Storage.getClient().users.cache.get(mention)
+
+              context.set(name, user)
+            }
+          } else {
+            /**
+             * If the argument is a numeric argument, thne we have
+             * to cast it to number
+             */
+            const value = type === Number ? Number(argValue) : argValue
+
+            context.set(name, value)
+          }
+
           ++i
         }
       }

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -1,7 +1,14 @@
+import { Client } from 'discord.js'
+
 import StaticCommandContract from './BaseCommand/StaticCommandContract'
 import { isString } from './utils/isType'
 
 export default class Storage {
+  /**
+   * The client
+   */
+  private static $client: Client | undefined = undefined
+
   /**
    * The commands
    */
@@ -19,6 +26,26 @@ export default class Storage {
    * mode
    */
   static __DEV_MODE = false
+
+  /**
+   * Gets the client
+   */
+  public static getClient() {
+    if (this.$client) {
+      return this.$client
+    }
+
+    throw new Error('Client is not defined, is Application already started?')
+  }
+
+  /**
+   * Sets the client
+   */
+  public static setClient(client: Client) {
+    this.$client = client
+
+    return this
+  }
 
   /**
    * Get the command by code


### PR DESCRIPTION
This PR introduces `User` type arguments or Mention arguments.

## `User` argument

In case of you need to receceive a mention as an argument as of:

```ts
!avatar @jotaajunior 
```

Previosuly you would have to do:

```ts
import { Command, BaseCommand } from 'discapp'

@Command('my-command')
export class Command extends BaseCommand {
  @Argument()
  public user: string
}
```

Then when you request `this.user` you would get something like: `<@!userid>` and have to work arround to get the User instance from Discord.js.

Now you can do:

```ts
import { Command, BaseCommand } from 'discapp'
import { User } from 'discord.js'

@Command('my-command')
export class Command extends BaseCommand {
  @Argument()
  public user: User
}
```

The code for doing that is pretty simple, but I had to do a workarround as I was getting bugs, since the package was not seeing the `User` from the Discapp application and the `User` from the package source as the same. I will later revisit this, as I think that maybe using Discord.js as a peer dependency  can potentially solve this problem.

Something similar happens to EmbedMessage returns.

## `Storage.getClient` / `Storage.setClient`

Now the Storage also stores the `Client` from Discord.js, this was necessary for implementing this featuure and I think this will also be useful in future features.